### PR TITLE
Expose event key decoder.

### DIFF
--- a/src/Keyboard.elm
+++ b/src/Keyboard.elm
@@ -9,6 +9,7 @@ module Keyboard
         , characterKey
         , downs
         , editingKey
+        , eventKeyDecoder
         , functionKey
         , mediaKey
         , modifierKey
@@ -121,6 +122,12 @@ rawValue (RawKey key) =
     key
 
 
+{-| Use this with Html keyboard events to retrieve a `RawKey` representing the key
+which triggered the event.
+
+    Html.Events.on "keydown" eventKeyDecoder
+
+-}
 eventKeyDecoder : Json.Decoder RawKey
 eventKeyDecoder =
     Json.field "key" (Json.string |> Json.map RawKey)


### PR DESCRIPTION
Exposing the decoder allows people to detect pressed keys outside of a `msg-update-view` cycle. Also allows packages like `Skinney/keyboard-events` to cut down on a lot of code, reducing asset size in applications which relies on such packages.