### PR TITLE
Case insensitive character keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: elm
+elm:
+  - '0.19.0'

--- a/elm.json
+++ b/elm.json
@@ -14,5 +14,7 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "1.2.1 <= v < 2.0.0"
+    }
 }

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -1,4 +1,4 @@
-module Main exposing (Model, Msg(..), init, main, subscriptions, update, view)
+module Main exposing (main)
 
 import Browser
 import Html exposing (Html, div, li, p, text, ul)

--- a/example/PlainSubscriptions.elm
+++ b/example/PlainSubscriptions.elm
@@ -1,4 +1,4 @@
-module PlainSubscriptions exposing (Model, Msg(..), init, keysView, main, subscriptions, update, view)
+module PlainSubscriptions exposing (main)
 
 import Browser
 import Html exposing (Html, div, li, p, text, ul)
@@ -54,10 +54,10 @@ update msg model =
         event =
             case msg of
                 KeyUp key ->
-                    "↥ up: " ++ Debug.toString (Keyboard.anyKey key)
+                    "↥ up: " ++ Debug.toString (Keyboard.anyKeyOriginal key)
 
                 KeyDown key ->
-                    "↧ down: " ++ Debug.toString (Keyboard.anyKey key)
+                    "↧ down: " ++ Debug.toString (Keyboard.anyKeyOriginal key)
 
                 ClearKeys ->
                     "↯ Clear!"

--- a/example/TrackingKeyChanges.elm
+++ b/example/TrackingKeyChanges.elm
@@ -1,4 +1,4 @@
-module TrackingKeyChanges exposing (Model, Msg(..), init, keysView, main, subscriptions, update, view)
+module TrackingKeyChanges exposing (main)
 
 import Browser
 import Html exposing (Html, div, li, p, text, ul)
@@ -39,7 +39,7 @@ update msg model =
         KeyboardMsg keyMsg ->
             let
                 ( pressedKeys, maybeKeyChange ) =
-                    Keyboard.updateWithKeyChange Keyboard.anyKey keyMsg model.pressedKeys
+                    Keyboard.updateWithKeyChange Keyboard.anyKeyOriginal keyMsg model.pressedKeys
 
                 keyChanges =
                     case maybeKeyChange of

--- a/src/Keyboard/Arrows.elm
+++ b/src/Keyboard/Arrows.elm
@@ -22,11 +22,11 @@ type alias Arrows =
     { x : Int, y : Int }
 
 
-{-| A key parser for just the Arrow keys and W, A, S, D.
+{-| A key parser for just the Arrow keys and W, A, S, D. They are always uppercase.
 
 [ArrowLeft] -> `Just ArrowLeft`
 
-[A] -> `Character "a"`
+[A] -> `Character "A"`
 
 [B] -> `Nothing`
 
@@ -61,11 +61,11 @@ arrowKey rawKey =
 
         other ->
             let
-                lower =
-                    String.toLower other
+                upper =
+                    String.toUpper other
             in
-            if lower == "w" || lower == "a" || lower == "s" || lower == "d" then
-                Just (Character other)
+            if upper == "W" || upper == "A" || upper == "S" || upper == "D" then
+                Just (Character upper)
 
             else
                 Nothing
@@ -118,15 +118,16 @@ arrows keys =
 wasd : List Key -> Arrows
 wasd keys =
     let
-        toInt char1 char2 =
-            boolToInt
-                (List.member (Character char1) keys || List.member (Character char2) keys)
+        toInt char =
+            keys
+                |> List.member (Character char)
+                |> boolToInt
 
         x =
-            toInt "D" "d" - toInt "A" "a"
+            toInt "D" - toInt "A"
 
         y =
-            toInt "W" "w" - toInt "S" "s"
+            toInt "W" - toInt "S"
     in
     { x = x, y = y }
 

--- a/tests/KeyboardTest.elm
+++ b/tests/KeyboardTest.elm
@@ -1,0 +1,116 @@
+module KeyboardTest exposing (suite)
+
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Json.Decode exposing (decodeString)
+import Json.Encode as Encode
+import Keyboard exposing (..)
+import Test exposing (..)
+import Tuple exposing (pair)
+
+
+suite : Test
+suite =
+    concat
+        [ fuzz keyboardEventJson "Decoder turns object to RawKey" <|
+            \{ original, json } ->
+                decodeString Keyboard.eventKeyDecoder json
+                    |> Result.map Keyboard.rawValue
+                    |> Expect.equal (Ok original)
+        , fuzz randomRawKey "Random raw key with no parsers" <|
+            \rawKey ->
+                rawKey
+                    |> Maybe.andThen (Keyboard.oneOf [])
+                    |> Expect.equal Nothing
+        , fuzz charRawKey "Character keys (always uppercase)" <|
+            \( original, rawKey ) ->
+                rawKey
+                    |> Maybe.andThen Keyboard.characterKeyUpper
+                    |> Expect.equal (Just (Character (String.toUpper original)))
+        , fuzz charRawKey "Character key with case" <|
+            \( original, rawKey ) ->
+                rawKey
+                    |> Maybe.andThen Keyboard.characterKeyOriginal
+                    |> Expect.equal (Just (Character original))
+        , describe "Non-ASCII characters" <|
+            List.map characterUpperTest nonAscii
+                ++ List.map (Tuple.first >> characterOriginalTest) nonAscii
+        ]
+
+
+nonAscii : List ( String, String )
+nonAscii =
+    [ pair "ä" "Ä"
+    , pair "å" "Å"
+    , pair "ñ" "Ñ"
+    , pair "Ñ" "Ñ"
+    , pair "ü" "Ü"
+    , pair "ï" "Ï"
+    , pair "â" "Â"
+    , pair "ø" "Ø"
+    , pair "€" "€"
+    , pair "½" "½"
+    ]
+
+
+characterUpperTest : ( String, String ) -> Test
+characterUpperTest ( original, expected ) =
+    stringToJson original
+        |> (\{ json } _ ->
+                decodeString Keyboard.eventKeyDecoder json
+                    |> Result.toMaybe
+                    |> Maybe.andThen Keyboard.characterKeyUpper
+                    |> Expect.equal (Just (Character expected))
+           )
+        |> test ("Uppercased " ++ original)
+
+
+characterOriginalTest : String -> Test
+characterOriginalTest original =
+    stringToJson original
+        |> (\{ json } _ ->
+                decodeString Keyboard.eventKeyDecoder json
+                    |> Result.toMaybe
+                    |> Maybe.andThen Keyboard.characterKeyOriginal
+                    |> Expect.equal (Just (Character original))
+           )
+        |> test ("With original case " ++ original)
+
+
+charRawKey : Fuzzer ( String, Maybe RawKey )
+charRawKey =
+    Fuzz.char
+        |> Fuzz.map (String.fromChar >> stringToJson)
+        |> Fuzz.map
+            (\{ original, json } ->
+                ( original
+                , json
+                    |> decodeString Keyboard.eventKeyDecoder
+                    |> Result.toMaybe
+                )
+            )
+
+
+randomRawKey : Fuzzer (Maybe RawKey)
+randomRawKey =
+    keyboardEventJson
+        |> Fuzz.map
+            (\{ json } ->
+                json
+                    |> decodeString Keyboard.eventKeyDecoder
+                    |> Result.toMaybe
+            )
+
+
+keyboardEventJson : Fuzzer { original : String, json : String }
+keyboardEventJson =
+    string
+        |> Fuzz.map stringToJson
+
+
+stringToJson : String -> { original : String, json : String }
+stringToJson value =
+    [ ( "key", Encode.string value ) ]
+        |> Encode.object
+        |> Encode.encode 0
+        |> (\json -> { original = value, json = json })


### PR DESCRIPTION
Major changes:

- Characters are always uppercase by default in the "Msg and update" way
- Instead of `anyKey` and `characterKey`, there's now `__Upper` and `__Original`
- Space is now `Spacebar` instead of `Character " "` in the `anyKeyUpper` and `anyKeyOriginal` parsers 

This fixes #3.